### PR TITLE
Fix runEngineCase for GridPro meshes in new environment + README.typo fix

### DIFF
--- a/AATE/README.md
+++ b/AATE/README.md
@@ -21,7 +21,7 @@ Users can download these meshes and run the engine simulation with them followin
 1. Download the meshes to your computer by executing the following command:
     ```bash
     cd meshes/GridPro/
-    ./downloadGridProMeshes <coarse|fine>
+    ./downloadMeshes <coarse|fine>
     ```
 
 2. Run the case using the downloaded meshes:

--- a/AATE/runEngineCase
+++ b/AATE/runEngineCase
@@ -75,7 +75,19 @@ if [ "$MESH_TYPE" = "snappy" ]; then
 
 else
     # Clone case and prepare for GridPro mesh
+    if [ ! -d "../meshes/GridPro/$MESH_TYPE" ]; then
+        echo "Error: GridPro mesh directory ../meshes/GridPro/$MESH_TYPE not found"
+        exit 1
+    fi
+
+    mkdir -p constant/meshes
     cp -r ../meshes/GridPro/$MESH_TYPE/* constant/meshes/
+
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to copy mesh files"
+        exit 1
+    fi
+    
     ls constant/meshes | sort -n > constant/meshTimes
 fi
 


### PR DESCRIPTION
`caseTemplate/constant/meshes` doesn't exist (probably due to empty folder being dropped out in Git), causing `runEngineCase` to fail when running with GridPro meshes in a fresh cloned environment. Fixed with a `mkdir` before copying the meshes in the script. Added brief error messages. Also corrected the mesh download script filename in `AATE/README.md` (`downloadGridProMeshes` -> `downloadMeshes`).